### PR TITLE
feat: add list and list item converters to enhance element handling

### DIFF
--- a/packages/tagflow/lib/src/converter/converter.dart
+++ b/packages/tagflow/lib/src/converter/converter.dart
@@ -131,6 +131,8 @@ class TagflowConverter {
       const BlockquoteFooterConverter(),
       const HrConverter(),
       const ContainerConverter(),
+      const ListConverter(),
+      const ListItemConverter(),
     ]);
   }
 

--- a/packages/tagflow/lib/src/converter/converters/converters.dart
+++ b/packages/tagflow/lib/src/converter/converters/converters.dart
@@ -3,4 +3,5 @@ export 'code_converter.dart';
 export 'container_converter.dart';
 export 'hr_converter.dart';
 export 'img_converter.dart';
+export 'list_converter.dart';
 export 'text_converter.dart';

--- a/packages/tagflow/lib/src/converter/converters/list_converter.dart
+++ b/packages/tagflow/lib/src/converter/converters/list_converter.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/cupertino.dart';
+import 'package:tagflow/tagflow.dart';
+
+final class ListConverter extends ElementConverter {
+  const ListConverter();
+
+  @override
+  Set<String> get supportedTags => {'ul', 'ol'};
+
+  @override
+  Widget convert(
+    TagflowElement element,
+    BuildContext context,
+    TagflowConverter converter,
+  ) {
+    final style = resolveStyle(element, context);
+    final children = converter.convertChildren(element.children, context);
+
+    return StyledContainer(
+      style: style,
+      tag: element.tag,
+      child: ListView(
+        physics: const NeverScrollableScrollPhysics(),
+        shrinkWrap: true,
+        children: children,
+      ),
+    );
+  }
+}
+
+final class ListItemConverter extends TextConverter {
+  const ListItemConverter();
+
+  @override
+  Set<String> get supportedTags => super.supportedTags.union({'li'});
+
+  @override
+  InlineSpan? getPrefix(TagflowElement element) {
+    final isOrdered = element.parent?.tag == 'ol';
+    final index = element.parent?.children.indexOf(element) ?? 0;
+    const noSpace = '\u00A0\u00A0';
+    return TextSpan(
+      text: isOrdered ? '${index + 1}.$noSpace' : '•$noSpace',
+    );
+  }
+}

--- a/packages/tagflow/lib/src/converter/converters/text_converter.dart
+++ b/packages/tagflow/lib/src/converter/converters/text_converter.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:tagflow/tagflow.dart';
 
 /// Converter for text elements
-final class TextConverter extends ElementConverter {
+class TextConverter extends ElementConverter {
   /// Create a new text converter
   const TextConverter();
 
@@ -55,12 +55,18 @@ final class TextConverter extends ElementConverter {
   ) {
     final style = resolveStyle(element, context);
     final children = _convertChildren(element, context, converter);
+    final prefix = getPrefix(element);
+    final suffix = getSuffix(element);
 
     return _wrapInContainerIfNeeded(
       Text.rich(
         TextSpan(
           text: element.textContent,
-          children: children,
+          children: [
+            if (prefix != null) prefix,
+            ...children,
+            if (suffix != null) suffix,
+          ],
           recognizer: _getGestures(element, context),
           mouseCursor: _getMouseCursor(element, context),
         ),
@@ -70,6 +76,16 @@ final class TextConverter extends ElementConverter {
       context,
       style,
     );
+  }
+
+  /// Get the prefix for a given element
+  InlineSpan? getPrefix(TagflowElement element) {
+    return null;
+  }
+
+  /// Get the suffix for a given element
+  InlineSpan? getSuffix(TagflowElement element) {
+    return null;
   }
 
   List<InlineSpan> _convertChildren(
@@ -147,7 +163,7 @@ final class TextConverter extends ElementConverter {
     TagflowElement element,
     TagflowStyle? resolvedStyle,
   ) {
-    if (element.tag == '#text') {
+    if (element.isTextNode) {
       return null;
     }
     return resolvedStyle?.textStyle;

--- a/packages/tagflow/lib/src/style/theme.dart
+++ b/packages/tagflow/lib/src/style/theme.dart
@@ -336,6 +336,10 @@ class TagflowTheme extends Equatable {
             vertical: baseFontSize * 0.125,
           ),
         ),
+        'li': TagflowStyle(
+          margin: EdgeInsets.only(bottom: baseFontSize),
+          padding: EdgeInsets.only(left: baseFontSize * 1.5),
+        ),
         ..._defaultStyles(baseFontSize, linkColor: linkColor ?? Colors.blue),
         if (additionalStyles != null) ...additionalStyles,
       },


### PR DESCRIPTION
- Introduced ListConverter and ListItemConverter to support 'ul', 'ol', and 'li' tags, improving the rendering of list elements in the Tagflow application.
- Updated the TagflowConverter to include the new converters, ensuring they are recognized during the conversion process.
- Enhanced the TextConverter to allow for prefix and suffix handling for list items, improving the visual representation of ordered and unordered lists.
- Updated TagflowTheme to include specific styles for list items, enhancing overall styling consistency.

These changes enrich the Tagflow application by providing better support for list structures and improving the overall layout and styling of list elements.

<sub><a href="https://huly.app/guest/tagflow?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZhOGRjNWYxNDRmNTg1YWU1MDA0ZDkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctbWUtdGFnZmxvdy02NzU5M2RiZi00ODIxNTFhN2VmLTUwMWIxNSJ9.D77XdQL-GdZ_2m-BorXCqSBcRnzyWBuWnQAqGXOIsFY">Huly&reg;: <b>TAGFL-21</b></a></sub>