### PR TITLE
fix: update Codecov action file parameter to 'files' for compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage/lcov.info
+          files: coverage/lcov.info


### PR DESCRIPTION
- Changed the parameter from 'file' to 'files' in the Codecov action configuration within the GitHub Actions workflow.
- This update ensures compatibility with the latest Codecov action requirements, improving the reliability of coverage report uploads.

<sub><a href="https://huly.app/guest/tagflow?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZhYTRhOWYxNDRmNTg1YWU1MDA4MzkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctbWUtdGFnZmxvdy02NzU5M2RiZi00ODIxNTFhN2VmLTUwMWIxNSJ9.LhCyXZtHEJH15N24NXBcqlcQIze5Dghoo8tyWn0FTj4">Huly&reg;: <b>TAGFL-24</b></a></sub>