### PR TITLE
chore(versioning): enhance GitHub Actions workflow to create releases

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -42,8 +42,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           PUB_CREDENTIALS: ${{ secrets.CREDENTIALS_JSON }}
 
-      - name: Create Git Tags
+      - name: Create Git Tags and Generate Changelog
+        id: release
         run: |
+          # Run version command and capture new version
           melos version --yes --no-git-tag-version --prerelease
+
+          # Generate the changelog
+          echo "CHANGELOG<<EOF" >> $GITHUB_ENV
+          melos changelog >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+          # Get the version for the release title
+          VERSION=$(melos list --json | jq -r '.[0].version')
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+          # Create and push tag
           melos exec -c 1 --no-private -- "git tag \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION"
           git push origin --tags
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: tagflow-v${{ env.VERSION }} # set by previous step
+          name: Release v${{ env.VERSION }} # set by previous step
+          body: ${{ env.CHANGELOG }} # set by previous step
+          prerelease: true # Since these are dev releases
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
… generate changelog

- Updated the versioning workflow to include a step for generating a changelog after version bumps.
- Captured the new version and created a Git tag for the release.
- Integrated the changelog into the GitHub release body, ensuring better documentation of changes for each release.
- Set the release as a prerelease, aligning with the development cycle.

<sub><a href="https://huly.app/guest/tagflow?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzZjZWU4NGYxNDRmNTg1YWU1MDhmMDQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctbWUtdGFnZmxvdy02NzU5M2RiZi00ODIxNTFhN2VmLTUwMWIxNSJ9.CIXL7QoJEEZIjsHDoTG1-OEi0kxOpQz01geplEoc3Qs">Huly&reg;: <b>TAGFL-39</b></a></sub>