### PR TITLE
test(gates): reflect beta release approval

### DIFF
--- a/packages/tagflow_benchmarks/test/native_runtime_gate_status_test.dart
+++ b/packages/tagflow_benchmarks/test/native_runtime_gate_status_test.dart
@@ -408,7 +408,7 @@ void main() {
     expect(draftResult.passed, isTrue);
     expect(
       draftResult.nonRequiredOpenGates.map((gate) => gate.id),
-      contains('release-approval'),
+      isNot(contains('release-approval')),
     );
     expect(
       draftResult.nonRequiredOpenGates.map((gate) => gate.id),
@@ -427,10 +427,9 @@ void main() {
     expect(betaPreapprovalResult.requiredOpenGates, isEmpty);
     expect(betaPreapprovalResult.profile.expectedOpenGateIds, isEmpty);
 
-    expect(betaResult.passed, isFalse);
-    expect(betaResult.issues.map((issue) => issue.details['gateId']), <String>[
-      'release-approval',
-    ]);
+    expect(betaResult.passed, isTrue);
+    expect(betaResult.issues, isEmpty);
+    expect(betaResult.requiredOpenGates, isEmpty);
     expect(
       betaResult.issues.map((issue) => issue.details['gateId']),
       isNot(contains('memory-allocation-review')),
@@ -503,7 +502,7 @@ void main() {
     );
   });
 
-  test('keeps coordination drafts out of repo manifest gate evidence', () {
+  test('keeps coordination drafts out of approved repo manifest evidence', () {
     final workspaceRoot = resolveWorkspaceRoot();
     final manifestFile = File(
       p.join(
@@ -519,10 +518,14 @@ void main() {
         .expand((gate) => gate.evidence)
         .map((entry) => entry.value);
 
-    expect(releaseGate?.status, NativeRuntimeGateStatus.deferred);
+    expect(releaseGate?.status, NativeRuntimeGateStatus.satisfied);
     expect(
       releaseGate?.evidence.map((entry) => entry.value),
       contains('docs/plans/2026-06-12-beta-release-approval-plan.md'),
+    );
+    expect(
+      releaseGate?.evidence.map((entry) => entry.value),
+      contains('docs/plans/2026-06-16-beta0-release-approval.md'),
     );
     expect(
       evidenceValues,


### PR DESCRIPTION
## Summary\n\nUpdates the native runtime gate manifest tests to match the approved 1.0.0-beta.0 release state after release-approval was marked satisfied.\n\n## Validation\n\n- PATH=/Users/arya/fvm/cache.git/bin:$PATH flutter test packages/tagflow_benchmarks/test/native_runtime_gate_status_test.dart\n- PATH=/Users/arya/fvm/cache.git/bin:$PATH TAGFLOW_NATIVE_RUNTIME_GATE_PROFILE=beta-candidate dart run melos run gate:native-runtime\n